### PR TITLE
eglplatform.h: if WL_EGL_PLATFORM is not defined use GBM

### DIFF
--- a/include/EGL/eglplatform.h
+++ b/include/EGL/eglplatform.h
@@ -73,14 +73,15 @@ typedef struct wl_display     *EGLNativeDisplayType;
 typedef struct wl_egl_pixmap  *EGLNativePixmapType;
 typedef struct wl_egl_window  *EGLNativeWindowType;
 
-#elif defined(__GBM__)
+#else
+
+struct gbm_device;
+struct gbm_bo;
 
 typedef struct gbm_device  *EGLNativeDisplayType;
 typedef struct gbm_bo      *EGLNativePixmapType;
 typedef void               *EGLNativeWindowType;
 
-#else
-#error "Platform not recognized"
 #endif
 
 /* EGL 1.2 types, renamed for consistency in EGL 1.3 */


### PR DESCRIPTION
Based on https://github.com/rockchip-linux/libmali/blob/29mirror/include/EGL/eglplatform.h#L70
- fixes proper EGL detection for several packages if `__GBM__` is not defined

