### PR TITLE
Install glesv1_cm pkg-config and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,25 +13,18 @@ elseif(MALI_VARIANT STREQUAL "450")
     set(MALI_FILE libmali-utgard-450-r7p0-gbm.so)
 elseif(MALI_VARIANT STREQUAL "t620")
     set(MALI_FILE libmali-midgard-t620-r12p0-wayland-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "t720")
     set(MALI_FILE libmali-midgard-t720-r18p0-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "t760" AND MALI_REVISION STREQUAL "r1p0")
     set(MALI_FILE libmali-midgard-t76x-r14p0-r1p0-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "t760")
     set(MALI_FILE libmali-midgard-t76x-r14p0-r0p0-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "t860")
     set(MALI_FILE libmali-midgard-t86x-r14p0-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "g31")
     set(MALI_FILE libmali-bifrost-g31-rxp0-gbm.so)
-    set(MALI_GLES3 ON)
 elseif(MALI_VARIANT STREQUAL "g52")
     set(MALI_FILE libmali-bifrost-g52-r16p0-wayland-gbm.so)
-    set(MALI_GLES3 ON)
 endif()
 
 configure_file(pkgconfig/egl.pc.cmake egl.pc @ONLY)
@@ -51,12 +44,9 @@ install(FILES include/gbm.h
 install(DIRECTORY include/EGL
                   include/GLES
                   include/GLES2
+                  include/GLES3
                   include/KHR
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-if(DEFINED MALI_GLES3)
-    install(DIRECTORY include/GLES3 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-endif()
 
 macro(install_symlink filepath sympath)
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${filepath} \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${sympath})")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ macro(install_symlink filepath sympath)
 endmacro(install_symlink)
 
 if(DEFINED MALI_FILE)
-    install(FILES lib/${MALI_ARCH}/${MALI_FILE} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(PROGRAMS lib/${MALI_ARCH}/${MALI_FILE} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install_symlink(${MALI_FILE} ${CMAKE_INSTALL_LIBDIR}/libmali.so)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libmali.so.0)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libMali.so)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,19 @@ configure_file(pkgconfig/egl.pc.cmake egl.pc @ONLY)
 configure_file(pkgconfig/gbm.pc.cmake gbm.pc @ONLY)
 configure_file(pkgconfig/glesv2.pc.cmake glesv2.pc @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/egl.pc ${CMAKE_CURRENT_BINARY_DIR}/gbm.pc ${CMAKE_CURRENT_BINARY_DIR}/glesv2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/egl.pc
+              ${CMAKE_CURRENT_BINARY_DIR}/gbm.pc
+              ${CMAKE_CURRENT_BINARY_DIR}/glesv2.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-install(FILES include/gbm.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY include/EGL include/GLES include/GLES2 include/KHR DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/gbm.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(DIRECTORY include/EGL
+                  include/GLES
+                  include/GLES2
+                  include/KHR
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(DEFINED MALI_GLES3)
     install(DIRECTORY include/GLES3 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,12 @@ endif()
 
 configure_file(pkgconfig/egl.pc.cmake egl.pc @ONLY)
 configure_file(pkgconfig/gbm.pc.cmake gbm.pc @ONLY)
+configure_file(pkgconfig/glesv1_cm.pc.cmake glesv1_cm.pc @ONLY)
 configure_file(pkgconfig/glesv2.pc.cmake glesv2.pc @ONLY)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/egl.pc
               ${CMAKE_CURRENT_BINARY_DIR}/gbm.pc
+              ${CMAKE_CURRENT_BINARY_DIR}/glesv1_cm.pc
               ${CMAKE_CURRENT_BINARY_DIR}/glesv2.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
@@ -68,7 +70,7 @@ if(DEFINED MALI_FILE)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libMali.so)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libEGL.so)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libEGL.so.1)
-    install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libGLES_CM.so.1)
+    install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libGLESv1_CM.so)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libGLESv1_CM.so.1)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libGLESv2.so)
     install_symlink(libmali.so ${CMAKE_INSTALL_LIBDIR}/libGLESv2.so.2)

--- a/include/GLES2/gl2ext.h
+++ b/include/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190326 */
+/* Generated on date 20190402 */
 
 /* Generated C header for:
  * API: gles2
@@ -3475,6 +3475,47 @@ GL_APICALL void GL_APIENTRY glScissorExclusiveArrayvNV (GLuint first, GLsizei co
 #ifndef GL_NV_shader_texture_footprint
 #define GL_NV_shader_texture_footprint 1
 #endif /* GL_NV_shader_texture_footprint */
+
+#ifndef GL_NV_shading_rate_image
+#define GL_NV_shading_rate_image 1
+#define GL_SHADING_RATE_IMAGE_NV          0x9563
+#define GL_SHADING_RATE_NO_INVOCATIONS_NV 0x9564
+#define GL_SHADING_RATE_1_INVOCATION_PER_PIXEL_NV 0x9565
+#define GL_SHADING_RATE_1_INVOCATION_PER_1X2_PIXELS_NV 0x9566
+#define GL_SHADING_RATE_1_INVOCATION_PER_2X1_PIXELS_NV 0x9567
+#define GL_SHADING_RATE_1_INVOCATION_PER_2X2_PIXELS_NV 0x9568
+#define GL_SHADING_RATE_1_INVOCATION_PER_2X4_PIXELS_NV 0x9569
+#define GL_SHADING_RATE_1_INVOCATION_PER_4X2_PIXELS_NV 0x956A
+#define GL_SHADING_RATE_1_INVOCATION_PER_4X4_PIXELS_NV 0x956B
+#define GL_SHADING_RATE_2_INVOCATIONS_PER_PIXEL_NV 0x956C
+#define GL_SHADING_RATE_4_INVOCATIONS_PER_PIXEL_NV 0x956D
+#define GL_SHADING_RATE_8_INVOCATIONS_PER_PIXEL_NV 0x956E
+#define GL_SHADING_RATE_16_INVOCATIONS_PER_PIXEL_NV 0x956F
+#define GL_SHADING_RATE_IMAGE_BINDING_NV  0x955B
+#define GL_SHADING_RATE_IMAGE_TEXEL_WIDTH_NV 0x955C
+#define GL_SHADING_RATE_IMAGE_TEXEL_HEIGHT_NV 0x955D
+#define GL_SHADING_RATE_IMAGE_PALETTE_SIZE_NV 0x955E
+#define GL_MAX_COARSE_FRAGMENT_SAMPLES_NV 0x955F
+#define GL_SHADING_RATE_SAMPLE_ORDER_DEFAULT_NV 0x95AE
+#define GL_SHADING_RATE_SAMPLE_ORDER_PIXEL_MAJOR_NV 0x95AF
+#define GL_SHADING_RATE_SAMPLE_ORDER_SAMPLE_MAJOR_NV 0x95B0
+typedef void (GL_APIENTRYP PFNGLBINDSHADINGRATEIMAGENVPROC) (GLuint texture);
+typedef void (GL_APIENTRYP PFNGLGETSHADINGRATEIMAGEPALETTENVPROC) (GLuint viewport, GLuint entry, GLenum *rate);
+typedef void (GL_APIENTRYP PFNGLGETSHADINGRATESAMPLELOCATIONIVNVPROC) (GLenum rate, GLuint samples, GLuint index, GLint *location);
+typedef void (GL_APIENTRYP PFNGLSHADINGRATEIMAGEBARRIERNVPROC) (GLboolean synchronize);
+typedef void (GL_APIENTRYP PFNGLSHADINGRATEIMAGEPALETTENVPROC) (GLuint viewport, GLuint first, GLsizei count, const GLenum *rates);
+typedef void (GL_APIENTRYP PFNGLSHADINGRATESAMPLEORDERNVPROC) (GLenum order);
+typedef void (GL_APIENTRYP PFNGLSHADINGRATESAMPLEORDERCUSTOMNVPROC) (GLenum rate, GLuint samples, const GLint *locations);
+#ifdef GL_GLEXT_PROTOTYPES
+GL_APICALL void GL_APIENTRY glBindShadingRateImageNV (GLuint texture);
+GL_APICALL void GL_APIENTRY glGetShadingRateImagePaletteNV (GLuint viewport, GLuint entry, GLenum *rate);
+GL_APICALL void GL_APIENTRY glGetShadingRateSampleLocationivNV (GLenum rate, GLuint samples, GLuint index, GLint *location);
+GL_APICALL void GL_APIENTRY glShadingRateImageBarrierNV (GLboolean synchronize);
+GL_APICALL void GL_APIENTRY glShadingRateImagePaletteNV (GLuint viewport, GLuint first, GLsizei count, const GLenum *rates);
+GL_APICALL void GL_APIENTRY glShadingRateSampleOrderNV (GLenum order);
+GL_APICALL void GL_APIENTRY glShadingRateSampleOrderCustomNV (GLenum rate, GLuint samples, const GLint *locations);
+#endif
+#endif /* GL_NV_shading_rate_image */
 
 #ifndef GL_NV_shadow_samplers_array
 #define GL_NV_shadow_samplers_array 1

--- a/pkgconfig/glesv1_cm.pc.cmake
+++ b/pkgconfig/glesv1_cm.pc.cmake
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: glesv1_cm
+Description: Mali OpenGL ES 1.1 CM library
+Version: 1.1
+Libs: -L${libdir} -lGLESv1_CM
+Libs.private: -lm -lpthread
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR updates GLES headers to 20190402, adds OpenGL ES 1.1 `glesv1_cm` pkg-config and changes to always install GLES3 headers.

@5schatten please test this on your targets, the OpenGL ES 1.0 `libGLES_CM.so.1` symlink was removed in favour of a OpenGL ES 1.1 `libGLESv1_CM.so` symlink and `glesv1_cm.pc`.